### PR TITLE
fix(upload): prevent single-class interpolation in data upload

### DIFF
--- a/pages/2_Data_Upload.py
+++ b/pages/2_Data_Upload.py
@@ -561,7 +561,7 @@ elif total_selected > 500:
 if total_selected > 1000:
     all_ready = False
 
-if all_ready and all(df is not None for _, df in class_dfs):
+if all_ready and all(df is not None for _, df in class_dfs) and int(n_classes) > 1:
     st.success(f"All {n_classes} classes loaded successfully.")
     mins, maxs = [], []
     for _, df in class_dfs:
@@ -608,7 +608,7 @@ if all_ready and all(df is not None for _, df in class_dfs):
             default_lbls_multi[col] = idx
     show_label_editor(combined_df, default_lbls_multi)
 
-elif all_ready and all(df is not None for _, df in class_dfs) and n_classes == 1:
+elif all_ready and all(df is not None for _, df in class_dfs) and int(n_classes) == 1:
     _, df = class_dfs[0]
     st.session_state.df     = df
     st.session_state.backup = df.copy() 


### PR DESCRIPTION
## Summary
- fix upload-page branching so interpolation/cropping runs only when class count is 2+
- preserve single-class uploaded dataframe as-is when handing off to Processing
- keep existing multi-class interpolation behavior unchanged

## Validation
- python3 -m py_compile pages/2_Data_Upload.py