### PR TITLE
fix analytics average column drops

### DIFF
--- a/pages/4_Analytics.py
+++ b/pages/4_Analytics.py
@@ -1101,7 +1101,7 @@ else:
             
             st.write("**Hierarchically-clustered Heatmap**")
             
-            temp = st.session_state.temp.drop(columns=['Average'])
+            temp = st.session_state.temp.drop(columns=['Average'], errors='ignore')
             
             if st.session_state.HCA_heatmap:
                 st.pyplot(function.hierarchical_clustering_heatmap(temp))
@@ -1114,7 +1114,7 @@ else:
         
         elif st.session_state.stats_plot_select == "Principal Components Analysis (PCA)":
             
-            temp = st.session_state.temp.drop(columns=['Average'])
+            temp = st.session_state.temp.drop(columns=['Average'], errors='ignore')
             label_df = st.session_state.get('label_df')
 
             if label_df is None:
@@ -1176,7 +1176,7 @@ else:
 
             st.write("**T‑Distributed stochastic neighbor embedding (t‑SNE)**")
 
-            temp = st.session_state.temp.drop(columns=['Average'])
+            temp = st.session_state.temp.drop(columns=['Average'], errors='ignore')
 
             label_df = st.session_state.get('label_df')   # could be None
 


### PR DESCRIPTION
  - Branch: hotfix/analytics-average-drop
  - Commit: 70d2814 fix analytics average column drops
  - Pushed to: origin/hotfix/analytics-average-drop

  Changed only pages/4_Analytics.py:1104: the three unsafe drop(columns=['Average']) calls now use errors='ignore' for
  HCA, PCA, and t-SNE.
